### PR TITLE
Add more languages

### DIFF
--- a/src/Hyphenated.js
+++ b/src/Hyphenated.js
@@ -1,14 +1,12 @@
 import React from 'react';
-import createHyphenator from 'hyphen';
-import hyphenationPatternsEnUs from 'hyphen/patterns/en-us';
+import { hyphenators } from './hyphenators';
 
-const hyphenate = createHyphenator(hyphenationPatternsEnUs);
-
-const Hyphenated = ({ children }) => {
+const Hyphenated = ({ children, language }) => {
   return React.Children.toArray(children).map(item => {
     if (item.type === Hyphenated) {
       return item;
     } else if (typeof item === 'string') {
+      const hyphenate = hyphenators.get(language);
       return hyphenate(item);
     } else {
       const { children, ...props } = item.props;

--- a/src/Hyphenated.test.js
+++ b/src/Hyphenated.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import Hyphenated from './Hyphenated';
-import { shallow, mount, render } from 'enzyme';
+import { enGb, de, fr } from './languages';
+
+import { shallow, render } from 'enzyme';
 
 const softHyphen = '\u00AD';
 const hyphenate = (...syllables) => syllables.join(softHyphen);
@@ -149,6 +151,64 @@ describe('Hyphenated', () => {
         'o',
         'nis',
         'tic to one’s own.'
+      )
+    );
+  });
+
+  it('hyphenates the text “antagonistic” differently for en-GB language', () => {
+    const wrapper = shallow(<Hyphenated>antagonistic</Hyphenated>);
+    const wrapperEnGb = shallow(
+      <Hyphenated language={enGb}>antagonistic</Hyphenated>
+    );
+    expect(wrapper.text()).toEqual(wrapper.text());
+    expect(wrapperEnGb.text()).toEqual(wrapperEnGb.text());
+    expect(wrapper.text()).not.toEqual(wrapperEnGb.text());
+  });
+
+  it('hyphenates multilingual text using a few instances', () => {
+    const wrapper = render(
+      <p>
+        <Hyphenated>
+          It is possible to hyphenate multilingual text.{' '}
+          <Hyphenated language={fr}>
+            Je suis l'itinéraire donné par Pierre, un ami français.
+          </Hyphenated>{' '}
+          <Hyphenated language={de}>
+            Das Universalgenie war nicht nur Schriftsteller, sondern auch
+            Rechtsanwalt.
+          </Hyphenated>{' '}
+          Just wrap it using an appropriate language.
+        </Hyphenated>
+      </p>
+    );
+    expect(wrapper.text()).toEqual(
+      hyphenate(
+        'It is pos',
+        'si',
+        'ble to hy',
+        'phen',
+        'ate mul',
+        'ti',
+        'lin',
+        "gual text. Je suis l'iti",
+        'né',
+        'raire don',
+        'né par Pierre, un ami fran',
+        'çais. Das Uni',
+        'ver',
+        'sal',
+        'ge',
+        'nie war nicht nur Schrift',
+        'stel',
+        'ler, son',
+        'dern auch Rechts',
+        'an',
+        'walt. Just wrap it us',
+        'ing an ap',
+        'pro',
+        'pri',
+        'ate lan',
+        'guage.'
       )
     );
   });

--- a/src/hyphenators.js
+++ b/src/hyphenators.js
@@ -1,0 +1,15 @@
+import createHyphenator from 'hyphen';
+import defaultLanguage from './languages/en-us';
+
+const cache = {};
+
+const hyphenators = {
+  get: (language = defaultLanguage) => {
+    if (!cache[language.id]) {
+      cache[language.id] = createHyphenator(language.patterns);
+    }
+    return cache[language.id];
+  }
+};
+
+export { hyphenators };

--- a/src/hyphenators.test.js
+++ b/src/hyphenators.test.js
@@ -1,0 +1,31 @@
+import createHyphenator from 'hyphen';
+import { enUs, enGb } from './languages';
+
+jest.mock('hyphen');
+createHyphenator.mockImplementation(() => () => {});
+
+describe('hyphenators', () => {
+  describe('get', () => {
+    afterEach(() => {
+      jest.resetModules();
+    });
+
+    it('creates a hyphenator for en-US language when called without args', () => {
+      const { hyphenators } = require('./hyphenators');
+      hyphenators.get();
+      expect(createHyphenator).toHaveBeenCalledWith(enUs.patterns);
+    });
+
+    it('creates a hyphenator only once when called without args', () => {
+      const { hyphenators } = require('./hyphenators');
+      expect(hyphenators.get()).toBe(hyphenators.get());
+      expect(createHyphenator).toHaveBeenCalledTimes(1);
+    });
+
+    it('creates a hyphenator only once for a particular language', () => {
+      const { hyphenators } = require('./hyphenators');
+      expect(hyphenators.get(enGb)).toBe(hyphenators.get(enGb));
+      expect(createHyphenator).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/languages/de.js
+++ b/src/languages/de.js
@@ -1,0 +1,5 @@
+import patterns from 'hyphen/patterns/de';
+export default {
+  patterns,
+  id: 'de'
+};

--- a/src/languages/en-gb.js
+++ b/src/languages/en-gb.js
@@ -1,0 +1,5 @@
+import patterns from 'hyphen/patterns/en-gb';
+export default {
+  patterns,
+  id: 'en-GB'
+};

--- a/src/languages/en-us.js
+++ b/src/languages/en-us.js
@@ -1,0 +1,5 @@
+import patterns from 'hyphen/patterns/en-us';
+export default {
+  patterns,
+  id: 'en-US'
+};

--- a/src/languages/fr.js
+++ b/src/languages/fr.js
@@ -1,0 +1,5 @@
+import patterns from 'hyphen/patterns/fr';
+export default {
+  patterns,
+  id: 'fr'
+};

--- a/src/languages/index.js
+++ b/src/languages/index.js
@@ -1,0 +1,4 @@
+export { default as enUs } from './en-us';
+export { default as enGb } from './en-gb';
+export { default as de } from './de';
+export { default as fr } from './fr';


### PR DESCRIPTION
- It’s possible to specify the language prop for `Hyphenated` component.
- Supported languages: American English, British English, French and German.