### PR TITLE
Use named export for languages modules and remove index

### DIFF
--- a/src/Hyphenated.test.js
+++ b/src/Hyphenated.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import Hyphenated from './Hyphenated';
-import { enGb, de, fr } from './languages';
+import { enGb } from './languages/en-gb';
+import { de } from './languages/de';
+import { fr } from './languages/fr';
 
 import { shallow, render } from 'enzyme';
 

--- a/src/hyphenators.js
+++ b/src/hyphenators.js
@@ -1,10 +1,10 @@
 import createHyphenator from 'hyphen';
-import defaultLanguage from './languages/en-us';
+import { enUs } from './languages/en-us';
 
 const cache = {};
 
 const hyphenators = {
-  get: (language = defaultLanguage) => {
+  get: (language = enUs) => {
     if (!cache[language.id]) {
       cache[language.id] = createHyphenator(language.patterns);
     }

--- a/src/hyphenators.test.js
+++ b/src/hyphenators.test.js
@@ -1,5 +1,6 @@
 import createHyphenator from 'hyphen';
-import { enUs, enGb } from './languages';
+import { enUs } from './languages/en-us';
+import { enGb } from './languages/en-gb';
 
 jest.mock('hyphen');
 createHyphenator.mockImplementation(() => () => {});

--- a/src/languages/de.js
+++ b/src/languages/de.js
@@ -1,5 +1,5 @@
 import patterns from 'hyphen/patterns/de';
-export default {
+export const de = {
   patterns,
   id: 'de'
 };

--- a/src/languages/en-gb.js
+++ b/src/languages/en-gb.js
@@ -1,5 +1,5 @@
 import patterns from 'hyphen/patterns/en-gb';
-export default {
+export const enGb = {
   patterns,
-  id: 'en-GB'
+  id: 'en-gb'
 };

--- a/src/languages/en-us.js
+++ b/src/languages/en-us.js
@@ -1,5 +1,5 @@
 import patterns from 'hyphen/patterns/en-us';
-export default {
+export const enUs = {
   patterns,
-  id: 'en-US'
+  id: 'en-us'
 };

--- a/src/languages/fr.js
+++ b/src/languages/fr.js
@@ -1,5 +1,5 @@
 import patterns from 'hyphen/patterns/fr';
-export default {
+export const fr = {
   patterns,
   id: 'fr'
 };

--- a/src/languages/index.js
+++ b/src/languages/index.js
@@ -1,4 +1,0 @@
-export { default as enUs } from './en-us';
-export { default as enGb } from './en-gb';
-export { default as de } from './de';
-export { default as fr } from './fr';


### PR DESCRIPTION
To allow tree shaking for the library users.