### PR TITLE
Fix an issue that language prop doesn’t pass down the components tree

### DIFF
--- a/src/Hyphenated.js
+++ b/src/Hyphenated.js
@@ -10,7 +10,11 @@ const Hyphenated = ({ children, language }) => {
     } else {
       const { children, ...props } = item.props;
       return children
-        ? React.cloneElement(item, props, <Hyphenated>{children}</Hyphenated>)
+        ? React.cloneElement(
+            item,
+            props,
+            <Hyphenated language={language}>{children}</Hyphenated>
+          )
         : item;
     }
   });

--- a/src/Hyphenated.test.js
+++ b/src/Hyphenated.test.js
@@ -176,11 +176,11 @@ describe('Hyphenated', () => {
         <Hyphenated>
           It is possible to hyphenate multilingual text.{' '}
           <Hyphenated language={fr}>
-            Je suis l'itinéraire donné par Pierre, un ami français.
+            Je suis l'itinéraire donné par Pierre, un ami <span>français</span>.
           </Hyphenated>{' '}
           <Hyphenated language={de}>
-            Das Universalgenie war nicht nur Schriftsteller, sondern auch
-            Rechtsanwalt.
+            Das <span>Universalgenie</span> war nicht nur Schriftsteller,
+            sondern auch Rechtsanwalt.
           </Hyphenated>{' '}
           Just wrap it using an appropriate language.
         </Hyphenated>


### PR DESCRIPTION
If `Hyphenated` is used with the `language` prop, it didn’t pass down to the nested components. This PR fixes it. 