### PR TITLE
Avoid rendering extra Hyphenated instances in virtual DOM

### DIFF
--- a/src/Hyphenated.js
+++ b/src/Hyphenated.js
@@ -10,11 +10,7 @@ const Hyphenated = ({ children, language }) => {
     } else {
       const { children, ...props } = item.props;
       return children
-        ? React.cloneElement(
-            item,
-            props,
-            <Hyphenated language={language}>{children}</Hyphenated>
-          )
+        ? React.cloneElement(item, props, Hyphenated({ children, language }))
         : item;
     }
   });

--- a/src/Hyphenated.test.js
+++ b/src/Hyphenated.test.js
@@ -5,7 +5,7 @@ import Hyphenated from './Hyphenated';
 import enGb from 'hyphenated-en-gb';
 import de from 'hyphenated-de';
 import fr from 'hyphenated-fr';
-import { shallow, render } from 'enzyme';
+import { shallow, mount, render } from 'enzyme';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -158,6 +158,24 @@ describe('Hyphenated', () => {
         'tic to one’s own.'
       )
     );
+  });
+
+  it('doesn’t add extra Hyphenated components to virtual DOM', () => {
+    const wrapper = mount(
+      <Hyphenated>
+        From Ambrose Bierce’s <em>Devil’s Dictionary</em>:
+        <Hyphenated>
+          <Paragraph>
+            <strong>
+              <Hyphenated>Scribbler</Hyphenated>
+            </strong>
+            , <em>n.</em> A professional writer whose views are antagonistic to
+            one’s own.
+          </Paragraph>
+        </Hyphenated>
+      </Hyphenated>
+    );
+    expect(wrapper.find(Hyphenated)).toHaveLength(3);
   });
 
   it('hyphenates the text “antagonistic” differently for en-GB language', () => {


### PR DESCRIPTION
The `Hyphenated` wrapper renders an extra `Hyphenated` component for each nested component which is a waste. This PR fixes it.