### PR TITLE
Avoid mapping single child to an array with one element

### DIFF
--- a/src/Hyphenated.js
+++ b/src/Hyphenated.js
@@ -2,18 +2,23 @@ import React from 'react';
 import { hyphenated } from 'hyphenated';
 
 const Hyphenated = ({ children, language }) => {
-  return React.Children.toArray(children).map(item => {
-    if (item.type === Hyphenated) {
-      return item;
-    } else if (typeof item === 'string') {
-      return hyphenated(item, { language });
+  const childrenCount = React.Children.count(children);
+  const hyphenateChild = child => {
+    if (child.type === Hyphenated) {
+      return child;
+    } else if (typeof child === 'string') {
+      return hyphenated(child, { language });
     } else {
-      const { children, ...props } = item.props;
+      const { children, ...props } = child.props;
       return children
-        ? React.cloneElement(item, props, Hyphenated({ children, language }))
-        : item;
+        ? React.cloneElement(child, props, Hyphenated({ children, language }))
+        : child;
     }
-  });
+  };
+  if (childrenCount === 1) {
+    return hyphenateChild(children);
+  }
+  return React.Children.map(children, hyphenateChild);
 };
 
 export default Hyphenated;

--- a/src/Hyphenated.test.js
+++ b/src/Hyphenated.test.js
@@ -178,6 +178,33 @@ describe('Hyphenated', () => {
     expect(wrapper.find(Hyphenated)).toHaveLength(3);
   });
 
+  it('preserves the only child of wrapped components which have the only child', () => {
+    const WrappedComponent = ({ children }) => children;
+    const wrapper = mount(
+      <Hyphenated>
+        <WrappedComponent>
+          <span>a single child</span>
+        </WrappedComponent>
+      </Hyphenated>
+    );
+    expect(() =>
+      React.Children.only(wrapper.find(WrappedComponent).props().children)
+    ).not.toThrow();
+  });
+
+  it('preserves no children of wrapped components which have no children', () => {
+    const WrappedComponent = () => null;
+    const wrapper = mount(
+      <Hyphenated>
+        <WrappedComponent />
+      </Hyphenated>
+    );
+    expect(wrapper.find(WrappedComponent)).toHaveLength(1);
+    expect(
+      React.Children.count(wrapper.find(WrappedComponent).props().children)
+    ).toBe(0);
+  });
+
   it('hyphenates the text “antagonistic” differently for en-GB language', () => {
     const wrapper = shallow(<Hyphenated>antagonistic</Hyphenated>);
     const wrapperEnGb = shallow(


### PR DESCRIPTION
Single child is mapped to a single child instead.