### PR TITLE
Avoid crash when there are null children

### DIFF
--- a/src/Hyphenated.js
+++ b/src/Hyphenated.js
@@ -4,7 +4,9 @@ import { hyphenated } from 'hyphenated';
 const Hyphenated = ({ children, language }) => {
   const childrenCount = React.Children.count(children);
   const hyphenateChild = child => {
-    if (child.type === Hyphenated) {
+    if (child === null) {
+      return null;
+    } else if (child.type === Hyphenated) {
       return child;
     } else if (typeof child === 'string') {
       return hyphenated(child, { language });

--- a/src/Hyphenated.test.js
+++ b/src/Hyphenated.test.js
@@ -262,4 +262,14 @@ describe('Hyphenated', () => {
       )
     );
   });
+
+  it('doesn’t crash if there are null children', () => {
+    render(
+      <Hyphenated>
+        <span>a child with text</span>
+        {null}
+        <span>a child with text</span>
+      </Hyphenated>
+    );
+  });
 });


### PR DESCRIPTION
Hi!  
I sometimes find it useful to conditionally render a string value, which may be falsey or undefined, like so:
```javascript
<Hyphenated>
  <h1>
    {part1 ? <span>{part1}</span> : null}
    {part2 ? <span>{part2}</span> : null}
  </h1>
</Hyphenated>
```

This would work fine without the Hyphenated component, but when using Hyphenated this would throw `TypeError: Cannot read property 'type' of null` in the null case.

This PR aims to fix that.